### PR TITLE
Scenario-form height fix attempt

### DIFF
--- a/app/assets/stylesheets/scenario_form.scss
+++ b/app/assets/stylesheets/scenario_form.scss
@@ -4,11 +4,11 @@
 
 .scenario {
 
-  width: 50%;
+  // width: 50%;
   max-width: 600px;
-  padding-top: 5vh;
-  height: calc(95vh - 104px); // 100vh - 5vh from padding 104px = 64px nav + 40px progress
-  margin: auto;
+  // padding-top: 5vh;
+  // height: calc(95vh - 104px); // 100vh - 5vh from padding 104px = 64px nav + 40px progress
+  margin: 0 auto;
   opacity: 1;
   transition: all 0.5s ease-in-out;
 


### PR DESCRIPTION
L'intégration de Clovis pose un souci de height sur le scénario form lorsqu'on est sur un Mac 13" (...comme le prof :( ) car le bouton pour passer à l'étape suivante n'est plus cliquable, masqué par la liste de bubulles pour passer à l'étape suivante.
![form-scenario](https://cloud.githubusercontent.com/assets/7700011/21387005/f6482e0e-c775-11e6-9d12-3dbdb4c8b7fb.png)

J'ai du coup désactivé la height sur .scenario, et le bouton redevient accessible. Cependant on se retrouve avec le background qui ne couvre pas tout et c'est pas très cool. Sauf si on retire le background-size: cover présent sur .content-wrapper il me semble.
